### PR TITLE
Keep sketch on top of other windows.

### DIFF
--- a/my-sketch/01/my-sketch/src/my_sketch/core.clj
+++ b/my-sketch/01/my-sketch/src/my_sketch/core.clj
@@ -26,4 +26,5 @@
   :setup setup
   :update update-state
   :draw draw-state
+  :features [:keep-on-top]
   :middleware [m/fun-mode])

--- a/my-sketch/02/my-sketch/src/my_sketch/core.clj
+++ b/my-sketch/02/my-sketch/src/my_sketch/core.clj
@@ -27,4 +27,5 @@
   :setup setup
   :update update-state
   :draw draw-state
+  :features [:keep-on-top]
   :middleware [m/fun-mode])

--- a/my-sketch/03/my-sketch/src/my_sketch/core.clj
+++ b/my-sketch/03/my-sketch/src/my_sketch/core.clj
@@ -33,4 +33,5 @@
   :setup setup
   :update update-state
   :draw draw-state
+  :features [:keep-on-top]
   :middleware [m/fun-mode])

--- a/my-sketch/04/my-sketch/src/my_sketch/core.clj
+++ b/my-sketch/04/my-sketch/src/my_sketch/core.clj
@@ -35,4 +35,5 @@
   :setup setup
   :update update-state
   :draw draw-state
+  :features [:keep-on-top]
   :middleware [m/fun-mode])

--- a/my-sketch/05/my-sketch/src/my_sketch/core.clj
+++ b/my-sketch/05/my-sketch/src/my_sketch/core.clj
@@ -39,4 +39,5 @@
   :setup setup
   :update update-state
   :draw draw-state
+  :features [:keep-on-top]
   :middleware [m/fun-mode])

--- a/my-sketch/06/my-sketch/src/my_sketch/core.clj
+++ b/my-sketch/06/my-sketch/src/my_sketch/core.clj
@@ -45,4 +45,5 @@
   :setup setup
   :update update-state
   :draw draw-state
+  :features [:keep-on-top]
   :middleware [m/fun-mode])


### PR DESCRIPTION
Sketches are "Always On Top."

**Positives:**
- Doesn't require moving windows around to accomodate sketch, for instant feedback.
- Mac users don't panic wondering why Quil doesn't work. (When the sketch is just [hiding under other windows](https://github.com/quil/quil/wiki/FAQ#i-cannot-see-sketch-on-os-x).)

**Negatives:**
- Code becomes 1 line more complex.
- Big sketches hide the text editor.

**Tested** on MacOS X.
