### PR TITLE
Simplify money calc

### DIFF
--- a/moneycalc/02/moneycalc/src/moneycalc/core.clj
+++ b/moneycalc/02/moneycalc/src/moneycalc/core.clj
@@ -7,13 +7,14 @@
 
 ;; tinker with data from Yahoo Finance web API
 
-(def response @(client/get "http://download.finance.yahoo.com/d/quotes.csv?s=USDEUR=X&f=price"))
+(def response @(client/get "http://download.finance.yahoo.com/d/quotes.csv?s=USDEUR=X&f=p"))
 (def body (slurp (:body response)))
-(def rate (first (string/split body #",")))
-rate
-(read-string rate)
+(def rate (read-string body))
 
-(def url "http://download.finance.yahoo.com/d/quotes.csv?s=%s%s=X&f=price")
+body
+rate
+
+(def url "http://download.finance.yahoo.com/d/quotes.csv?s=%s%s=X&f=p")
 
 (format url "EUR" "USD")
 

--- a/moneycalc/03/moneycalc/src/moneycalc/core.clj
+++ b/moneycalc/03/moneycalc/src/moneycalc/core.clj
@@ -7,7 +7,7 @@
 
 ;; Access currency exchange rate with Yahoo Finance web API
 
-(def url "http://download.finance.yahoo.com/d/quotes.csv?s=%s%s=X&f=price")
+(def url "http://download.finance.yahoo.com/d/quotes.csv?s=%s%s=X&f=p")
 
 (defn query-money-exchange-rate
   "Returns a floating point number that represents
@@ -18,7 +18,7 @@
   (let [url       (format url to-symbol from-symbol)
         response @(client/get url)
         body      (slurp (:body response))
-        rate      (read-string (first (string/split body #",")))]
+        rate      (read-string body)]
     (if (number? rate)
       rate)))
 

--- a/moneycalc/04/moneycalc/src/moneycalc/core.clj
+++ b/moneycalc/04/moneycalc/src/moneycalc/core.clj
@@ -28,11 +28,11 @@
 
 
 (defn render-rate
-  [to-symbol from-symbol]
+  [rate to-symbol from-symbol]
   [:tr
    [:td from-symbol]
    [:td to-symbol]
-   [:td (query-money-exchange-rate to-symbol from-symbol)]])
+   [:td rate]])
 
 
 (defn handler
@@ -44,7 +44,8 @@
                   [:table
                    [:thead [:tr [:th "From"] [:th "To"] [:th "Rate"]]]
                    [:body (for [t ["EUR" "USD"] f ["JPY" "AUD"]]
-                                   (render-rate t f))]]])})
+                            (if-let [rate (query-money-exchange-rate t f)]
+                              (render-rate rate t f)))]]])})
 
 
 

--- a/moneycalc/04/moneycalc/src/moneycalc/core.clj
+++ b/moneycalc/04/moneycalc/src/moneycalc/core.clj
@@ -8,7 +8,7 @@
 
 ;; Access currency exchange rate with Yahoo Finance web API
 
-(def url "http://download.finance.yahoo.com/d/quotes.csv?s=%s%s=X&f=price")
+(def url "http://download.finance.yahoo.com/d/quotes.csv?s=%s%s=X&f=p")
 
 (defn query-money-exchange-rate
   "Returns a floating point number that represents
@@ -19,7 +19,7 @@
   (let [url       (format url to-symbol from-symbol)
         response @(client/get url)
         body      (slurp (:body response))
-        rate      (read-string (first (string/split body #",")))]
+        rate      (read-string body)]
     (if (number? rate)
       rate)))
 

--- a/moneycalc/05/moneycalc/.gitignore
+++ b/moneycalc/05/moneycalc/.gitignore
@@ -1,0 +1,11 @@
+/target
+/classes
+/checkouts
+pom.xml
+pom.xml.asc
+*.jar
+*.class
+/.lein-*
+/.nrepl-port
+.hgignore
+.hg/

--- a/moneycalc/05/moneycalc/project.clj
+++ b/moneycalc/05/moneycalc/project.clj
@@ -1,0 +1,11 @@
+(defproject moneycalc "0.1.0-SNAPSHOT"
+  :description "Calculating currency amounts"
+  :url "http://example.com/FIXME"
+  :license {:name "Eclipse Public License"
+            :url "http://www.eclipse.org/legal/epl-v10.html"}
+  :dependencies [[org.clojure/clojure "1.6.0"]
+                 [http-kit "2.1.19"]
+                 [hiccup "1.0.5"]
+                 [ring "1.3.2"]
+                 [ring/ring-defaults "0.1.5"]
+                 [compojure "1.3.4"]])

--- a/moneycalc/05/moneycalc/src/moneycalc/core.clj
+++ b/moneycalc/05/moneycalc/src/moneycalc/core.clj
@@ -1,0 +1,80 @@
+(ns moneycalc.core
+  (:require [org.httpkit.server :as server]
+            [org.httpkit.client :as client]
+            [clojure.string :as string]
+            [hiccup.core :as h]
+            [ring.middleware.defaults :refer [wrap-defaults site-defaults]]))
+
+
+;; Access currency exchange rate with Yahoo Finance web API
+
+(def url "http://download.finance.yahoo.com/d/quotes.csv?s=%s%s=X&f=pc1")
+
+(defn query-money-exchange-stats
+  "Returns a map with keys `rate` and `change` whose values
+  represent the conversion rate and change between two currencies
+  as floating point numbers (e.g. {:rate 1.1283, :change -0.002}).
+  Typical symbols are EUR, USD, CAD, NZD, JPY, AUD, NOK.
+  Returns nil if no rate can be found."
+  [to-symbol from-symbol]
+  (let [url       (format url to-symbol from-symbol)
+        response @(client/get url)
+        body      (slurp (:body response))
+        [rate change] (map read-string (string/split body #","))]
+    (if (number? rate)
+      {:rate rate :change change})))
+
+;; uncomment to test it
+#_(query-money-exchange-stats "EUR" "USD")
+
+
+(defn render-rate
+  [stats to-symbol from-symbol]
+  [:tr
+   [:td from-symbol]
+   [:td to-symbol]
+   [:td (:rate stats)]
+   [:td (:change stats)]])
+
+
+(defn handler
+  [request]
+  {:status 200
+   :headers {"Content-Type" "text/html"}
+   :body (h/html [:body
+                  [:h1 "Hello Hiccup World"]
+                  [:table
+                   [:thead [:tr [:th "From"] [:th "To"] [:th "Rate"] [:th "Change"]]]
+                   [:body (for [t ["EUR" "USD"] f ["JPY" "AUD"]]
+                            (if-let [stats (query-money-exchange-stats t f)]
+                              (render-rate stats t f)))]]])})
+
+
+
+(def app (wrap-defaults #'handler site-defaults))
+
+
+;; -------------------------------------------------------------------
+;; http server start/stop infrastructure
+
+(defonce http-server (atom nil))
+
+(defn stop!
+  "Stops the http server if started."
+  []
+  (when-let [shutdown-fn @http-server]
+    (shutdown-fn)
+    (reset! http-server nil)
+    :stopped))
+
+
+(defn start!
+  "Starts http server, which is reachable on http://localhost:8080"
+  []
+  (stop!)
+  (reset! http-server (server/run-server #'app {:port 8080}))
+  :started)
+
+
+(stop!)
+(start!)


### PR DESCRIPTION
I think the example can be simplified by fetching **just the actual value** for `Previous Close` [1] -
therefore not requiring any CSV "parsing" [2].

However, attendees will still get the chance to do some "parsing" once they get to [step 5](https://github.com/friemen/kickstart/commit/719658a01e82693725d97adf39c1a262138744d9) [3].

---

[1] [Yahoo Finance API for CSV](http://www.jarloo.com/yahoo_finance/)

[2]

``` bash
$ curl 'http://download.finance.yahoo.com/d/quotes.csv?s=EURUSD=X&f=price'
1.1283,N/A,N/A,"-0.0044 - -0.3913%",N/A

$ curl 'http://download.finance.yahoo.com/d/quotes.csv?s=EURUSD=X&f=p'
1.1283
```

[3]

``` bash
$ curl 'http://download.finance.yahoo.com/d/quotes.csv?s=EURUSD=X&f=pc1'
1.2997,+0.0044
```
